### PR TITLE
Fix indentation in gitconfig

### DIFF
--- a/dotfiles/gitconfig
+++ b/dotfiles/gitconfig
@@ -20,7 +20,7 @@
 	cp = cherry-pick
 	br = branch
 	staged = diff --staged
-  st = diff --staged
+	st = diff --staged
 	amend = commit --amend
 	ammend = commit --amend
 	lg = log --graph --pretty=format:'%C(cyan)%h%Creset - %s %Cgreen(%cr) %C(blue)<%an>%C(yellow)%d%Creset' --abbrev-commit


### PR DESCRIPTION
One of the aliases in the gitconfig file was not properly indented. This change fixes that.